### PR TITLE
Add kind config

### DIFF
--- a/hack/test/kind/kind-cfg.yaml
+++ b/hack/test/kind/kind-cfg.yaml
@@ -1,0 +1,12 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: ./patches
+        containerPath: /patches
+kubeadmConfigPatches:
+  - |
+    kind: InitConfiguration
+    patches:
+      directory: /patches

--- a/hack/test/kind/main.sh
+++ b/hack/test/kind/main.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Include the magic
+. /home/mneverov/Temp/demo-magic/demo-magic.sh
+
+
+DIR="$( pwd )"
+
+pushd "$DIR" >/dev/null 2>&1 || exit
+trap "{ popd >/dev/null 2>&1; }" EXIT
+
+cd hack/test/kind || exit
+
+DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
+
+# Clear the screen before starting
+clear
+
+pe "# creating kind cluster with kube-controller-manager --allocate-node-cidrs=false"
+
+pei "kind create cluster --config ./kind-cfg.yaml"
+PROMPT_TIMEOUT=12
+wait
+
+# should be visible
+popd >/dev/null 2>&1 || exit
+
+pei "# create ClusterCIDR CRD"
+PROMPT_TIMEOUT=1
+wait
+pei "kl create -f ./config/crd/networking.x-k8s.io_clustercidrs.yaml"
+wait
+
+pei "# create ClusterCIDR sample"
+wait
+pei "bat ./samples/clustercidr.yaml"
+PROMPT_TIMEOUT=5
+wait
+pei "kl create -f ./samples/clustercidr.yaml"
+PROMPT_TIMEOUT=1
+wait
+
+pei "#run clusterCIDR Controller"
+wait
+pei "./bin/manager --kubeconfig=/home/mneverov/.kube/config"
+
+PROMPT_TIMEOUT=0
+p ""
+cmd

--- a/hack/test/kind/patches/kube-controller-manager.yaml
+++ b/hack/test/kind/patches/kube-controller-manager.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+spec:
+  containers:
+    - name: kube-controller-manager
+      env:
+        - name: foo
+          value: "bar"
+      command:
+        - kube-controller-manager
+        - --allocate-node-cidrs=false
+        - --authentication-kubeconfig=/etc/kubernetes/controller-manager.conf
+        - --authorization-kubeconfig=/etc/kubernetes/controller-manager.conf
+        - --bind-address=127.0.0.1
+        - --client-ca-file=/etc/kubernetes/pki/ca.crt
+        - --cluster-cidr=10.244.0.0/16
+        - --cluster-name=kind
+        - --cluster-signing-cert-file=/etc/kubernetes/pki/ca.crt
+        - --cluster-signing-key-file=/etc/kubernetes/pki/ca.key
+        - --controllers=*,bootstrapsigner,tokencleaner
+        - --enable-hostpath-provisioner=true
+        - --kubeconfig=/etc/kubernetes/controller-manager.conf
+        - --leader-elect=true
+        - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
+        - --root-ca-file=/etc/kubernetes/pki/ca.crt
+        - --service-account-private-key-file=/etc/kubernetes/pki/sa.key
+        - --service-cluster-ip-range=10.96.0.0/16
+        - --use-service-account-credentials=true

--- a/hack/test/kind/watch.sh
+++ b/hack/test/kind/watch.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Include the magic
+. /home/mneverov/Temp/demo-magic/demo-magic.sh
+
+
+DIR="$( pwd )"
+
+pushd "$DIR" >/dev/null 2>&1 || exit
+trap "{ popd >/dev/null 2>&1; }" EXIT
+
+cd hack/test/kind || exit
+
+DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
+
+# Clear the screen before starting
+clear
+
+# Print and execute a simple command
+pe "# watching control-plane node CIDR"
+
+PROMPT_TIMEOUT=0
+wait
+
+# Wait until the user presses enter
+pei "watch \" kl get node kind-control-plane -ojson | jq -r '{cidr: .spec.podCIDR, cidrs: .spec.podCIDRs}'\""

--- a/samples/clustercidr.yaml
+++ b/samples/clustercidr.yaml
@@ -4,5 +4,5 @@ metadata:
   name: clustercidr-test
 spec:
   perNodeHostBits: 8
-  ipv4: 10.10.10.0/8
-  ipv6: 2001:db8::/64
+  ipv4: 10.244.0.0/16
+  ipv6: 2001:db8::/110


### PR DESCRIPTION
To run the controller in kind we need to disable node cluster CIDR allocation. This is done in this PR by providing kind configs.