### PR TITLE
Add health and readiness endpoints.

### DIFF
--- a/charts/cluster-cidr-controller/templates/deployment.yaml
+++ b/charts/cluster-cidr-controller/templates/deployment.yaml
@@ -33,12 +33,16 @@ spec:
               protocol: TCP
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
+            initialDelaySeconds: 15
+            periodSeconds: 20
           readinessProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/cluster-cidr-controller/values.yaml
+++ b/charts/cluster-cidr-controller/values.yaml
@@ -28,7 +28,7 @@ securityContext:
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8081
 
 resources:
   limits:

--- a/main.go
+++ b/main.go
@@ -21,21 +21,17 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const defaultResync = 30 * time.Second
+func main() {
+	var (
+		apiServerURL    string
+		kubeconfig      string
+		healthProbeAddr string
+	)
 
-var (
-	apiServerURL    string
-	kubeconfig      string
-	healthProbeAddr string
-)
-
-func init() {
 	flag.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&apiServerURL, "apiserver", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	flag.StringVar(&healthProbeAddr, "health-probe-address", ":8081", "Specifies the TCP address for the health server to listen on.")
-}
 
-func main() {
 	klog.InitFlags(nil)
 	flag.Parse()
 
@@ -60,6 +56,7 @@ func main() {
 		klog.FlushAndExit(klog.ExitFlushTimeout, 1)
 	}
 
+	const defaultResync = 30 * time.Second
 	kubeInformerFactory := kubeinformers.NewSharedInformerFactory(kubeClient, defaultResync)
 	sharedInformerFactory := informers.NewSharedInformerFactory(cidrClient, defaultResync)
 


### PR DESCRIPTION
Add standard go webserver with `/healthz` and `/readyz` endpoints. The port is changed from 80 to 8081 - default kubebuilder health port -- even if kubebuilder is not used, it is nice to have a standard default port IMO.
Addresses #16.

ON_HOLD: depends on #12 if we use webhooks then this PR is obsolete and standard controller manager can be used