### PR TITLE
Fix codegen.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ lint: ## Run golangci check.
 KUBEBUILDER_ASSETS=$(shell go run sigs.k8s.io/controller-runtime/tools/setup-envtest use $(ENVTEST_K8S_VERSION) -p path)
 
 .PHONY: test
-test: manifests generate fmt ## Run tests.
+test: fmt ## Run tests.
 	KUBEBUILDER_ASSETS="$(KUBEBUILDER_ASSETS)" go test ./... -coverprofile cover.out
 
 ##@ Build

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,6 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+PROJECT="github.com/mneverov/cluster-cidr-controller"
 PROJECT_ROOT=$(realpath $(dirname "${BASH_SOURCE[0]}")/..)
 
 CODEGEN_VERSION=$(go list -m -f '{{.Version}}' k8s.io/code-generator)
@@ -28,13 +29,13 @@ cd $(dirname "${BASH_SOURCE[0]}")/..
 source "${CODEGEN_PKG}/kube_codegen.sh"
 
 kube::codegen::gen_helpers \
-    --input-pkg-root github.com/mneverov/cluster-cidr-controller/pkg/apis \
-    --output-base "${PROJECT_ROOT}" \
-    --boilerplate "${PROJECT_ROOT}/hack/boilerplate.go.txt"
+    --input-pkg-root "${PROJECT}/pkg/apis" \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../.." \
+    --boilerplate "${PROJECT_ROOT}/hack/boilerplate.go.txt" \
 
 kube::codegen::gen_client \
     --with-watch \
-    --input-pkg-root github.com/mneverov/cluster-cidr-controller/pkg/apis \
-    --output-pkg-root github.com/mneverov/cluster-cidr-controller/pkg/client \
-    --output-base "PROJECT_ROOT" \
+    --input-pkg-root "${PROJECT}/pkg/apis" \
+    --output-pkg-root "${PROJECT}/pkg/client" \
+    --output-base "$(dirname "${BASH_SOURCE[0]}")/../../../.." \
     --boilerplate "${PROJECT_ROOT}/hack/boilerplate.go.txt"


### PR DESCRIPTION
Previously, `test` target in makefile ran on both `manifests` and `generate` targets. This was done to make sure that tests always run against up-to-date manifests and generated code. [checkout](https://github.com/mneverov/cluster-cidr-controller/blob/main/.github/workflows/test.yml#L16) action in GH clones repo in `/home/runner/work/cluster-cidr-controller` directory, that does not follow go convention (`/home/user/go/src/github.com/...`). [update_codegen](https://github.com/mneverov/cluster-cidr-controller/blob/main/hack/update-codegen.sh#L32) operates with packages, i.e. `--input-pkg-root` is the name of the package that should be aligned with the repo structure, i.e. `github.com/mneverov/cluster-cidr-controller/pkg/apis`. The `--output-base` directory must be specified such that when cd from that directory into the package it must be the root of the repo i.e. from hack folder `cd ../../../.. && cd github.com/mneverov/cluster-controller-cidr` ==> root of the project.
This PR removes the dependency of the `test` target on `manifests` and `generate` and fixes the `output-base` so the code is correctly generated