### PR TITLE
tryfixcodegen

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,15 +27,18 @@ jobs:
           version: v1.54
 
   test:
-    runs-on: ubuntu-latest
     name: Run Tests
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          path: github.com/mneverov/cluster-cidr-controller
 
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: go.mod
+          go-version-file: github.com/mneverov/cluster-cidr-controller/go.mod
 
       - name: Test
+        working-directory: github.com/mneverov/cluster-cidr-controller
         run: make test

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -27,6 +27,9 @@ cd $(dirname "${BASH_SOURCE[0]}")/..
 
 source "${CODEGEN_PKG}/kube_codegen.sh"
 
+ln -s ../.. github.com
+trap "rm github.com" EXIT
+
 kube::codegen::gen_helpers \
     --input-pkg-root github.com/mneverov/cluster-cidr-controller/pkg/apis \
     --output-base "${PROJECT_ROOT}" \
@@ -36,5 +39,5 @@ kube::codegen::gen_client \
     --with-watch \
     --input-pkg-root github.com/mneverov/cluster-cidr-controller/pkg/apis \
     --output-pkg-root github.com/mneverov/cluster-cidr-controller/pkg/client \
-    --output-base "PROJECT_ROOT" \
+    --output-base "${PROJECT_ROOT}" \
     --boilerplate "${PROJECT_ROOT}/hack/boilerplate.go.txt"


### PR DESCRIPTION
Codegen rely on the default go project directory path i.e. `$GOPATH/github.com/owner/repo`. GH [checkout action](https://github.com/mneverov/cluster-cidr-controller/blob/main/.github/workflows/test.yml#L16) clones repo in `/home/runner/work/cluster-cidr-controller` directory, that does not follow go convention.
This PR specifies additional path where to clone the repo relative to the GH working directory. It also creates a link in the root of the repo to `github.com` so the `--output-base` of the codegen works.