### PR TITLE
use host network deployment.yaml

### DIFF
--- a/charts/cluster-cidr-controller/templates/deployment.yaml
+++ b/charts/cluster-cidr-controller/templates/deployment.yaml
@@ -18,6 +18,7 @@ spec:
       labels:
         {{- include "cluster-cidr-controller.selectorLabels" . | nindent 8 }}
     spec:
+      hostNetwork: true
       serviceAccountName: {{ include "cluster-cidr-controller.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}


### PR DESCRIPTION
IF the controller depends on the cni we'll heave a chicken an egg problem:

the CNI, in this case kindnet, needs the controller to set the node.spec.PodCIDR value  ... and the controller needs the CNI to provide an IP

controller MUST use hostNetwork: true, not familiar with helm so feel free to readjust to achieve that